### PR TITLE
Add devise confirmable module to User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,23 +3,28 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  unconfirmed_email      :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, and :trackable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: [:google_oauth2]
 end

--- a/db/migrate/20210126135346_add_confirmable_to_devise_users.rb
+++ b/db/migrate/20210126135346_add_confirmable_to_devise_users.rb
@@ -1,0 +1,12 @@
+class AddConfirmableToDeviseUsers < ActiveRecord::Migration[6.1]
+  def change
+    change_table :users, bulk: true do |t|
+      t.string :confirmation_token
+      t.string :unconfirmed_email
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+    end
+
+    add_index :users, :confirmation_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_02_175013) do
+ActiveRecord::Schema.define(version: 2021_01_26_135346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,11 @@ ActiveRecord::Schema.define(version: 2021_01_02_175013) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "confirmation_token"
+    t.string "unconfirmed_email"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,16 +3,21 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  unconfirmed_email      :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -23,7 +23,8 @@
 #
 FactoryBot.define do
   factory :user do
-    email    { Faker::Internet.unique.email }
-    password { Faker::Internet.password(min_length: 8) }
+    email        { Faker::Internet.unique.email }
+    password     { Faker::Internet.password(min_length: 8) }
+    confirmed_at { Time.current }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,16 +3,21 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
+#  unconfirmed_email      :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #
 # Indexes
 #
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #

--- a/spec/system/users/edit_user_spec.rb
+++ b/spec/system/users/edit_user_spec.rb
@@ -28,7 +28,9 @@ feature 'Edit user' do
       fill_in 'Current password', with: password
       click_on 'Update'
 
-      expect(page).to have_text('Your account has been updated successfully')
+      expect(page).to have_text(
+        'You updated your account successfully, but we need to verify your new email address'
+      )
       expect(page).to have_current_path(root_path)
     end
   end

--- a/spec/system/users/sign_in_spec.rb
+++ b/spec/system/users/sign_in_spec.rb
@@ -5,30 +5,48 @@ require 'rails_helper'
 feature 'User sign in' do
   let(:email) { Faker::Internet.email }
   let(:password) { Faker::Internet.password(min_length: 8) }
-  let!(:user) { create(:user, email: email, password: password) }
 
-  feature 'with correct credentials' do
-    scenario 'signs in successfully' do
+  feature 'when user has confirmed account' do
+    let!(:user) { create(:user, email: email, password: password) }
+
+    feature 'with correct credentials' do
+      scenario 'signs in successfully' do
+        visit new_user_session_path
+
+        fill_in 'Email', with: email
+        fill_in 'Password', with: password
+        click_on 'Log in'
+
+        expect(page).to have_text('Signed in successfully')
+        expect(page).to have_current_path(root_path)
+      end
+    end
+
+    feature 'with incorrect credentials' do
+      scenario 'fails to sign in' do
+        visit new_user_session_path
+
+        fill_in 'Email', with: email
+        fill_in 'Password', with: 'incorrect password'
+        click_on 'Log in'
+
+        expect(page).to have_text('Invalid Email or password')
+        expect(page).to have_current_path(new_user_session_path)
+      end
+    end
+  end
+
+  feature 'when user has unconfirmed account' do
+    let!(:user) { create(:user, email: email, password: password, confirmed_at: nil) }
+
+    scenario 'fails to sign in' do
       visit new_user_session_path
 
       fill_in 'Email', with: email
       fill_in 'Password', with: password
       click_on 'Log in'
 
-      expect(page).to have_text('Signed in successfully')
-      expect(page).to have_current_path(root_path)
-    end
-  end
-
-  feature 'with incorrect credentials' do
-    scenario 'fails to sign in' do
-      visit new_user_session_path
-
-      fill_in 'Email', with: email
-      fill_in 'Password', with: 'incorrect password'
-      click_on 'Log in'
-
-      expect(page).to have_text('Invalid Email or password')
+      expect(page).to have_text('You have to confirm your email address before continuing')
       expect(page).to have_current_path(new_user_session_path)
     end
   end

--- a/spec/system/users/sign_up_spec.rb
+++ b/spec/system/users/sign_up_spec.rb
@@ -15,7 +15,8 @@ feature 'User sign up' do
       fill_in 'Password confirmation', with: password
       click_on 'Sign up'
 
-      expect(page).to have_text('Welcome! You have signed up successfully')
+      expect(page).to have_text('A message with a confirmation link has been sent to your email address.')
+      expect(page).to have_text('Please follow the link to activate your account')
       expect(page).to have_current_path(root_path)
     end
   end


### PR DESCRIPTION
This PR adds confirmable module to User as mentioned in [this card](https://github.com/rootstrap/rails_hotwire_base/projects/1#card-52773599), based on [Devise documentation](https://github.com/heartcombo/devise/wiki/How-To:-Add-:confirmable-to-Users)