### PR TITLE
Use connection string for production env

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -81,6 +81,4 @@ test:
 #
 production:
   <<: *default
-  database: rails_hotwire_base_production
-  username: rails_hotwire_base
-  password: <%= ENV['RAILS_HOTWIRE_BASE_DATABASE_PASSWORD'] %>
+  url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
Heroku and other PaaS services provide the connection to the database information via a `DATABASE_URL` string which contains the database:
- host
- port
- username
- password
- database name
Now production env can use this string to connect to the database automatically.