### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'sass-rails', '>= 6'
 # An utility first CSS framework
 gem 'tailwindcss-rails', '~> 0.3.0'
 # A framework for building reusable, testable & encapsulated view components in Ruby on Rails
-gem 'view_component', '~> 2.24', require: 'view_component/engine'
+gem 'view_component'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 5.0'
 # Easing the form object pattern in Rails applications.


### PR DESCRIPTION
Patches the "DEPRECATION WARNING: This manually engine loading is deprecated and will be removed in v3.0.0. Remove `require "view_component/engine"  mesage while loading or bundling the aplication